### PR TITLE
fix column names in get_mids

### DIFF
--- a/coolpuppy/__main__.py
+++ b/coolpuppy/__main__.py
@@ -1,5 +1,6 @@
 from .coolpup import *
 from .plotpup import *
+from coolpuppy import *
 import cooler
 import pandas as pd
 import os

--- a/coolpuppy/__main__.py
+++ b/coolpuppy/__main__.py
@@ -1,6 +1,5 @@
 from .coolpup import *
 from .plotpup import *
-from coolpuppy import *
 import cooler
 import pandas as pd
 import os
@@ -309,7 +308,7 @@ def main():
             import json
             with open(os.path.join(args.outdir, outname)[:-4] + '.json', 'w') as fp:
                 json.dump(outdict, fp)#, sort_keys=True, indent=4)
-
+        global prepare_single
         def prepare_single(item, outname=outname):
             key, amap = item
 #            coords = (key[0], int(key[1]), int(key[2]))

--- a/coolpuppy/__main__.py
+++ b/coolpuppy/__main__.py
@@ -309,26 +309,6 @@ def main():
             import json
             with open(os.path.join(args.outdir, outname)[:-4] + '.json', 'w') as fp:
                 json.dump(outdict, fp)#, sort_keys=True, indent=4)
-        
-        global prepare_single
-
-        def prepare_single(item, outname=outname):
-            key, amap = item
-#            coords = (key[0], int(key[1]), int(key[2]))
-            enr1 = get_enrichment(amap, 1)
-            enr3 = get_enrichment(amap, 3)
-            cv3 = cornerCV(amap, 3)
-            cv5 = cornerCV(amap, 5)
-#            if args.save_all:
-#                outname = outname + '_%s:%s-%s.np.txt' % coords
-#                try:
-#                    np.savetxt(os.path.join(args.outdir, 'individual', outname),
-#                               amap)
-#                except FileNotFoundError:
-#                    os.mkdir(os.path.join(args.outdir, 'individual'))
-#                    np.savetxt(os.path.join(args.outdir, 'individual', outname),
-#                               amap)
-            return list(key)+[enr1, enr3, cv3, cv5]
 
         p = Pool(nproc)
         data = p.map(prepare_single, finloops.items())

--- a/coolpuppy/coolpup.py
+++ b/coolpuppy/coolpup.py
@@ -60,7 +60,6 @@ def get_mids(intervals, resolution, combinations=True):
                              'Pad2':widths2/2},
                             ).drop_duplicates(['chr1', 'chr2',
                                 'Bin1', 'Bin2'])#.drop(['Bin1', 'Bin2'], axis=1)
->>>>>>> fix column names in get_mids
     return mids
 
 def get_combinations(mids, res, local=False, anchor=None):

--- a/coolpuppy/coolpup.py
+++ b/coolpuppy/coolpup.py
@@ -87,6 +87,14 @@ def get_positions_pairs(mids, res):
     p2 = (mids['Pad2']//res).astype(int).values
     for posdata in zip(m1, m2, p1, p2):
         yield posdata
+    
+def prepare_single(item):
+    key, amap = item
+    enr1 = get_enrichment(amap, 1)
+    enr3 = get_enrichment(amap, 3)
+    cv3 = cornerCV(amap, 3)
+    cv5 = cornerCV(amap, 5)
+    return list(key)+[enr1, enr3, cv3, cv5]
 
 def controlRegions(midcombs, res, minshift=10**5, maxshift=10**6, nshifts=1):
     minbin = minshift//res

--- a/coolpuppy/coolpup.py
+++ b/coolpuppy/coolpup.py
@@ -60,6 +60,7 @@ def get_mids(intervals, resolution, combinations=True):
                              'Pad2':widths2/2},
                             ).drop_duplicates(['chr1', 'chr2',
                                 'Bin1', 'Bin2'])#.drop(['Bin1', 'Bin2'], axis=1)
+>>>>>>> fix column names in get_mids
     return mids
 
 def get_combinations(mids, res, local=False, anchor=None):


### PR DESCRIPTION
When running coolpup using a 2D bed file, I was getting the following error:

```
Traceback (most recent call last):
  File "/pasteur/scratch/users/cmatthey/softwares/anaconda3/bin/coolpup.py", line 10, in <module>
    sys.exit(main())
  File "/pasteur/scratch/users/cmatthey/softwares/anaconda3/lib/python3.7/site-packages/coolpuppy/__main__.py", line 237, in main
    mids = get_mids(bases, resolution=c.binsize, combinations=combinations)
  File "/pasteur/scratch/users/cmatthey/softwares/anaconda3/lib/python3.7/site-packages/coolpuppy/coolpup.py", line 63, in get_mids
    'Bin1', 'Bin2']).drop(['Bin1',
  File "/pasteur/scratch/users/cmatthey/softwares/anaconda3/lib/python3.7/site-packages/pandas/core/frame.py", line 4331, in drop_duplicates
    duplicated = self.duplicated(subset, keep=keep)
  File "/pasteur/scratch/users/cmatthey/softwares/anaconda3/lib/python3.7/site-packages/pandas/core/frame.py", line 4381, in duplicated
    raise KeyError(diff)
KeyError: Index(['chr'], dtype='object')
```

When looking at get_mids, I found that the 'chr' column was not supposed to be present and that there was a mistake  at line 64 where spaces were inserted in the column name. 

After correcting this, the program worked fine. Thanks for the nice and convenient software  :)