### PR TITLE
prevent crash on --save_all

### DIFF
--- a/coolpuppy/__main__.py
+++ b/coolpuppy/__main__.py
@@ -390,9 +390,10 @@ def main():
             outdict = {'%s:%s-%s' % key : (val[0], val[1].tolist())
                                                for key,val in finloops.items()}
             import json
-            with open(os.path.join(args.outdir, outname)[:-4] + '.json', 'w') as fp:
+            json_path = os.path.join(args.outdir, os.path.splitext(outname)[0]) + '.json'
+            with open(json_path, 'w') as fp:
                 json.dump(outdict, fp)#, sort_keys=True, indent=4)
-                logging.info("Saved individual pileups to %s.json" % os.path.join(args.outdir, outname)[:-4])
+                logging.info("Saved individual pileups to %s" % json_path)
     else:
         loop = pileupsWithControl(mids=mids, mids2=mids2,
                                   ordered_mids=args.bed2_ordered,

--- a/coolpuppy/coolpup.py
+++ b/coolpuppy/coolpup.py
@@ -614,7 +614,7 @@ def pileupsByWindowWithControl(mids, filename, pad=100, nproc=1, chroms=None,
                 rescale=rescale, rescale_pad=rescale_pad,
                 rescale_size=rescale_size,
                 seed=seed)
-    chrommids = chrom_mids(chroms, mids, True)
+    chrommids = chrom_mids(chroms, mids, 'bed')
     loops = {chrom:lps for chrom, lps in zip(chroms,
                                              p.map(f, chrommids))}
     #Controls
@@ -627,7 +627,7 @@ def pileupsByWindowWithControl(mids, filename, pad=100, nproc=1, chroms=None,
                     rescale=rescale, rescale_pad=rescale_pad,
                     rescale_size=rescale_size,
                     seed=seed)
-        chrommids = chrom_mids(chroms, mids, True)
+        chrommids = chrom_mids(chroms, mids, 'bed')
         ctrls = {chrom:lps for chrom, lps in zip(chroms,
                                              p.map(f, chrommids))}
     elif expected is not False:
@@ -639,7 +639,7 @@ def pileupsByWindowWithControl(mids, filename, pad=100, nproc=1, chroms=None,
             rescale=rescale, rescale_pad=rescale_pad,
             rescale_size=rescale_size,
             seed=seed)
-        chrommids = chrom_mids(chroms, mids, True)
+        chrommids = chrom_mids(chroms, mids, 'bed')
         ctrls = {chrom:lps for chrom, lps in zip(chroms,
                                              p.map(f, chrommids))}
     p.close()


### PR DESCRIPTION
Hello, 

This merge request attempts to fix two issues:
1.  The `--save_all` and `--by_window` options caused the following error when used with a BED file input (not BEDPE). This crash seems to happen because the value of `kind` is set to `True` when calling `chrom_mids()` from `pileupsByWindowWithControl()`. This was equivalent to calling `chrom_mids()` with `kind='bedpe'`

```
Traceback (most recent call last):
  File "/home/cmatthey/anaconda3/bin/coolpup.py", line 11, in <module>
    load_entry_point('coolpuppy', 'console_scripts', 'coolpup.py')()
  File "/home/cmatthey/Repos/coolpuppy/coolpuppy/__main__.py", line 360, in main
    rescale_size=args.rescale_size)
  File "/home/cmatthey/Repos/coolpuppy/coolpuppy/coolpup.py", line 607, in pileupsByWindowWithControl
    p.map(f, chrommids))}
  File "/home/cmatthey/anaconda3/lib/python3.7/multiprocessing/pool.py", line 268, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/home/cmatthey/anaconda3/lib/python3.7/multiprocessing/pool.py", line 383, in _map_async
    iterable = list(iterable)
  File "/home/cmatthey/Repos/coolpuppy/coolpuppy/coolpup.py", line 350, in chrom_mids
    yield chrom, mids[mids['chr1']==chrom]
```
If I understand correctly, `pileupsByWindowWithControl()` should only be called when kind='bed'. I therefore replaced `kind=True` with `kind='bed'`.
2. When using `--save_all`, the filename of the JSON was truncated by 4 characters to remove the ".txt" extension. When the user defines a filename without extension (or with a different one), this caused the name to be incomplete. I replaced the truncation with a os.path.splitext call.